### PR TITLE
Add support for running as an Xcode build plugin

### DIFF
--- a/Plugins/SwiftLint/main.swift
+++ b/Plugins/SwiftLint/main.swift
@@ -30,3 +30,27 @@ struct SwiftLintPlugin: BuildToolPlugin {
         ]
     }
 }
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SwiftLintPlugin: XcodeBuildToolPlugin {
+    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+        return [
+            .buildCommand(
+                displayName: "Running SwiftLint for \(target.displayName)",
+                executable: try context.tool(named: "swiftlint").path,
+                arguments: [
+                    "lint",
+                    "--in-process-sourcekit",
+                    "--path",
+                    context.xcodeProject.directory.string,
+                    "--config",
+                    "\(context.xcodeProject.directory.string)/.swiftlint.yml"
+                ],
+                environment: [:]
+            )
+        ]
+    }
+}
+#endif


### PR DESCRIPTION
To be able to run this plugin as part of a regular Xcode build it needs to extend `XcodeBuildToolPlugin`. This PR adds support for this :)