### PR TITLE
Set plugin cache path

### DIFF
--- a/Plugins/SwiftLint/main.swift
+++ b/Plugins/SwiftLint/main.swift
@@ -23,7 +23,9 @@ struct SwiftLintPlugin: BuildToolPlugin {
                     "--path",
                     target.directory.string,
                     "--config",
-                    "\(context.package.directory.string)/.swiftlint.yml"
+                    "\(context.package.directory.string)/.swiftlint.yml",
+                    "--cache-path",
+                    "\(context.pluginWorkDirectory.string)/cache"
                 ],
                 environment: [:]
             )
@@ -46,7 +48,9 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
                     "--path",
                     context.xcodeProject.directory.string,
                     "--config",
-                    "\(context.xcodeProject.directory.string)/.swiftlint.yml"
+                    "\(context.xcodeProject.directory.string)/.swiftlint.yml",
+                    "--cache-path",
+                    "\(context.pluginWorkDirectory.string)/cache"
                 ],
                 environment: [:]
             )


### PR DESCRIPTION
Hey, thanks for being so quick on merging my last PR! 😃 

Here's another one. Noticed a warning in my build logs about SwiftLint not being able to cache its data and figured out SPM plugins actually get a working directory that can be used for exactly this! From the docs (of `PluginContext.pluginWorkDirectory`):

> The path of a writable directory into which the plugin or the build commands it constructs can write anything it wants. This could include any generated source files that should be processed further, and it could include any caches used by the build tool or the plugin itself. The plugin is in complete control of what is written under this directory, and the contents are preserved between builds.
>
> A plugin would usually create a separate subdirectory of this directory for each command it creates, and the command would be configured to write its outputs to that directory. **The plugin may also create other directories for cache files and other file system content that either it or the command will need.**