### PR TITLE
Command Plugin for fixing linting errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,19 +13,33 @@ let package = Package(
     products: [
         .plugin(
             name: "SwiftLint",
-            targets: ["SwiftLint"]),
-    ],
-    dependencies: [
+            targets: ["SwiftLint"]
+        ),
+        .plugin(
+            name: "SwiftLintFix",
+            targets: ["SwiftLintFix"]
+        ),
     ],
     targets: [
         .binaryTarget(
             name: "SwiftLintBinary",
-            url: "https://github.com/realm/SwiftLint/releases/download/0.47.1/SwiftLintBinary-macos.artifactbundle.zip",
-            checksum: "82ef90b7d76b02e41edd73423687d9cedf0bb9849dcbedad8df3a461e5a7b555"
+            url: "https://github.com/realm/SwiftLint/releases/download/0.49.1/SwiftLintBinary-macos.artifactbundle.zip",
+            checksum: "227258fdb2f920f8ce90d4f08d019e1b0db5a4ad2090afa012fd7c2c91716df3"
         ),
+
         .plugin(
             name: "SwiftLint",
             capability: .buildTool(),
-            dependencies: ["SwiftLintBinary"]),
+            dependencies: ["SwiftLintBinary"]
+        ),
+
+        .plugin(
+            name: "SwiftLintFix",
+            capability: .command(
+                intent: .sourceCodeFormatting(),
+                permissions: [.writeToPackageDirectory(reason: "Fixes fixable lint issues")]
+            ),
+            dependencies: ["SwiftLintBinary"]
+        ),
     ]
 )

--- a/Plugins/SwiftLint/main.swift
+++ b/Plugins/SwiftLint/main.swift
@@ -19,13 +19,11 @@ struct SwiftLintPlugin: BuildToolPlugin {
                 executable: try context.tool(named: "swiftlint").path,
                 arguments: [
                     "lint",
-                    "--in-process-sourcekit",
-                    "--path",
-                    target.directory.string,
                     "--config",
                     "\(context.package.directory.string)/.swiftlint.yml",
                     "--cache-path",
-                    "\(context.pluginWorkDirectory.string)/cache"
+                    "\(context.pluginWorkDirectory.string)/cache",
+                    target.directory.string
                 ],
                 environment: [:]
             )
@@ -44,13 +42,11 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
                 executable: try context.tool(named: "swiftlint").path,
                 arguments: [
                     "lint",
-                    "--in-process-sourcekit",
-                    "--path",
-                    context.xcodeProject.directory.string,
                     "--config",
                     "\(context.xcodeProject.directory.string)/.swiftlint.yml",
                     "--cache-path",
-                    "\(context.pluginWorkDirectory.string)/cache"
+                    "\(context.pluginWorkDirectory.string)/cache",
+                    context.xcodeProject.directory.string
                 ],
                 environment: [:]
             )

--- a/Plugins/SwiftLintFix/main.swift
+++ b/Plugins/SwiftLintFix/main.swift
@@ -1,0 +1,43 @@
+//
+//  File.swift
+//  
+//
+//  Created by Lukas Pistrol on 31.10.22.
+//
+
+import PackagePlugin
+import Foundation
+
+@main
+struct MyCommandPlugin: CommandPlugin {
+
+    func performCommand(context: PluginContext, arguments: [String]) throws {
+        let tool = try context.tool(named: "swiftlint")
+        let toolUrl = URL(fileURLWithPath: tool.path.string)
+
+        for target in context.package.targets {
+            guard let target = target as? SourceModuleTarget else { continue }
+
+            let process = Process()
+            process.executableURL = toolUrl
+            process.arguments = [
+                "--fix",
+                "--config",
+                "\(context.package.directory.string)/.swiftlint.yml",
+                "\(target.directory)"
+            ]
+
+            print(toolUrl.path, process.arguments!.joined(separator: " "))
+
+            try process.run()
+            process.waitUntilExit()
+
+            if process.terminationReason == .exit && process.terminationStatus == 0 {
+                print("Formatted the source code in \(target.directory).")
+            } else {
+                let problem = "\(process.terminationReason):\(process.terminationStatus)"
+                Diagnostics.error("swift-format invocation failed: \(problem)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements a new command plugin that can be invoked on any target in a project. It is basically a shortcut for running `swiftlint --fix`.

It also removes some deprecated options:
- `--in-process-sourcekit` is no longer needed since it is used by default.
- `path` is no longer needed. 