### PR TITLE
Disable swiftlint using DISABLE_SWIFTLINT env var

### DIFF
--- a/Plugins/SwiftLint/main.swift
+++ b/Plugins/SwiftLint/main.swift
@@ -8,11 +8,15 @@
 //  https://github.com/realm/SwiftLint/issues/3840#issuecomment-1085699163
 //
 
+import Foundation
 import PackagePlugin
 
 @main
 struct SwiftLintPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        if ProcessInfo().environment["DISABLE_SWIFTLINT"] != nil {
+            return []
+        }
         return [
             .buildCommand(
                 displayName: "Running SwiftLint for \(target.name)",

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ xcodebuild  \
     clean build
 ```
 
+If you need to disable linting (for release/app store builds), you can set`DISABLE_SWIFTLINT` environment variable
+
 -----
 
 <a href="https://www.buymeacoffee.com/lukeeep" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>


### PR DESCRIPTION
For CI builds of releases to submit to the App Store, we don't need the linter to be executed, setting the `DISABLE_SWIFTLINT` env var