### PR TITLE
Adjust min supported OS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "SwiftLintPlugin",
     platforms: [
-        .iOS(.v13),
-        .watchOS(.v6),
-        .macOS(.v10_15),
-        .tvOS(.v13),
+        .iOS(.v12),
+        .watchOS(.v4),
+        .macOS(.v12),
+        .tvOS(.v12),
     ],
     products: [
         .plugin(


### PR DESCRIPTION
### Description

Working on https://github.com/maplibre/maplibre-navigation-ios/pull/37 we had to increase our deployment target from iOS12 to iOS13. We don't mind bumping the version if it's necessary but we are hesitant to do it only for tooling.

### Tasks

- [x] reduce min supported version to iOS12

### Infos for Reviewer

A quick integration on our side shows that it works correctly. Xcode 15.3 last supported version without deprecation warning is iOS12. The official SwiftLint Package states macOS12, instead of 10_15 as min supported version, so I've fixed this as well. Not sure if the precompiled binary even works on such old machines.

![Bildschirmfoto 2024-04-13 um 12 47 06](https://github.com/lukepistrol/SwiftLintPlugin/assets/18739004/a439a6c9-0664-45f5-b95a-41cdd9b858ec)
